### PR TITLE
SYS7_1 Autopilot <_/_equals> correction in two iterations

### DIFF
--- a/Voodoomaster/Systems/SYS7_1_autopilot.xml
+++ b/Voodoomaster/Systems/SYS7_1_autopilot.xml
@@ -535,11 +535,11 @@
 					<equals>
 						<property>/autopilot/locks/altitude</property>
 						<value>gs1-hold</value>
-					<equals>
+					</equals>
 					<equals>
 						<property>/instrumentation/nav[0]/gs-in-range</property>
 						<value>true</value>
-					<equals>
+					</equals>
 				</and>
 			</condition>
 		</enable>
@@ -574,11 +574,11 @@
 					<equals>
 						<property>/autopilot/locks/altitude</property>
 						<value>gs1-hold</value>
-					<equals>
+					</equals>
 					<equals>
 						<property>/instrumentation/nav[0]/gs-in-range</property>
 						<value>false</value>
-					<equals>
+					</equals>
 				</and>
 			</condition>
 		</enable>


### PR DESCRIPTION
Hi Jwocky
While organizing the b29 around I found the SYS7_1 autopilot was an invalid xml. 
I found that Probably two closing tags </equals> lacked the bacslash. 

This commit fixes that.
Best,
IH-COL
